### PR TITLE
Added a function to gather duration statistics

### DIFF
--- a/sdk/internal/metrics/duration.go
+++ b/sdk/internal/metrics/duration.go
@@ -1,0 +1,72 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	cloudwatchfetcher "github.com/dominikhei/aws-lambda-analyzer/sdk/internal/cloudwatch"
+	logsinsightsfetcher "github.com/dominikhei/aws-lambda-analyzer/sdk/internal/logsinsights"
+	"github.com/dominikhei/aws-lambda-analyzer/sdk/internal/queries"
+	"github.com/dominikhei/aws-lambda-analyzer/sdk/internal/utils"
+	sdktypes "github.com/dominikhei/aws-lambda-analyzer/sdk/types"
+	sdkerrors "github.com/dominikhei/aws-lambda-analyzer/sdk/errors"
+)
+// This function does not use the duration metric from cloudwatch, as
+// there is a risk of aggregating durations depending on the period.
+
+
+func GetDurationStatistics(
+	ctx context.Context,
+	logsFetcher *logsinsightsfetcher.Fetcher,
+	cwFetcher *cloudwatchfetcher.Fetcher,
+	query sdktypes.FunctionQuery,
+	period int32,
+) (*sdktypes.DurationStatisticsReturn, error) {
+    invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum", period)
+    if err != nil {
+        return nil, fmt.Errorf("fetch invocations metric: %w", err)
+    }
+    invocationsSum, err := sumMetricValues(invocationsResults)
+    if err != nil {
+        return nil, fmt.Errorf("parse invocations metric data: %w", err)
+    }
+    if invocationsSum == 0 {
+        return nil, sdkerrors.NewNoInvocationsError(query.FunctionName)
+    }
+
+    escapedQualifier := strings.ReplaceAll(query.Qualifier, "$", "\\$")
+    queryString := fmt.Sprintf(queries.LambdaDurationQueryWithVersion, escapedQualifier)
+    results, err := logsFetcher.RunQuery(ctx, query, queryString)
+	if err != nil {
+		return nil, fmt.Errorf("run logs insights query: %w", err)
+	}
+	var durations []float64
+	for _, row := range results {
+		if valStr, ok := row["durationMs"]; ok {
+			if val, err := strconv.ParseFloat(valStr, 64); err == nil {
+				durations = append(durations, val)
+			} else {
+				fmt.Printf("warn: could not parse %q as float64: %v", valStr, err)
+			}
+		}
+	}
+	durationStats, err := utils.CalcSummaryStats(durations)
+	if err != nil {
+		return nil, fmt.Errorf("error calculating summary statistics: %w", err)
+	}
+	return &sdktypes.DurationStatisticsReturn{
+		MinDuration: durationStats.Min,
+        MaxDuration: durationStats.Max,
+        MedianDuration: durationStats.Median,
+		MeanDuration: durationStats.Mean,
+        P95Duration: durationStats.P95,
+        P99Duration: durationStats.P99,
+		Conf95Duration: durationStats.ConfInt95,
+        FunctionName: query.FunctionName,
+        Qualifier:    query.Qualifier,
+        StartTime:    query.StartTime,
+        EndTime:      query.EndTime,
+	}, nil
+}

--- a/sdk/internal/queries/queries.go
+++ b/sdk/internal/queries/queries.go
@@ -5,11 +5,16 @@ filter @message like /Status: timeout/ and @logStream like /\[%s\]/
 | stats count_distinct(@requestId) as timeoutCount
 `
 
-
 const LambdaMemoryUtilizationQueryWithVersion = `
 parse @message "Memory Size: * MB\tMax Memory Used: * MB" as memorySize, maxMemoryUsed 
 | filter ispresent(memorySize) and ispresent(maxMemoryUsed)  and @logStream like /\[%s\]/
 | display @timestamp, memorySize, maxMemoryUsed, maxMemoryUsed / memorySize as memoryUtilizationRatio
+`
+
+const LambdaDurationQueryWithVersion = `
+fields @timestamp, @message
+| parse @message "Duration: * ms" as durationMs
+| filter ispresent(durationMs) and @logStream like /\[%s\]/
 `
 
 const LambdaColdStartRateWithVersion = `

--- a/sdk/internal/utils/utils.go
+++ b/sdk/internal/utils/utils.go
@@ -116,9 +116,6 @@ func FunctionExists(ctx context.Context, client *lambda.Client, functionName str
 }
 
 func QualifierExists(ctx context.Context, client *lambda.Client, functionName, qualifier string) (bool, error) {
-    if qualifier == "" {
-        return true, nil
-    }
     _, err := client.GetFunction(ctx, &lambda.GetFunctionInput{
         FunctionName: aws.String(functionName),
         Qualifier:    aws.String(qualifier),

--- a/sdk/types/types.go
+++ b/sdk/types/types.go
@@ -105,3 +105,18 @@ type ErrorTypesReturn struct {
 	StartTime    time.Time                `json:"startTime"`
 	EndTime      time.Time                `json:"endTime"`
 }
+
+// MemoryUsagePercentilesReturn holds various statistics on the maximum used memory of invocations
+type DurationStatisticsReturn struct{
+        MinDuration    float32 // Min duration of any run
+        MaxDuration    float32 // Max duration of any run
+        MedianDuration float32 // Median duration of any run
+		MeanDuration   float32 // Mean duration of any run
+        P95Duration    *float32 // Pointers as these values can be nil
+        P99Duration    *float32 // in case of too little samples
+		Conf95Duration *float32 // 95% confidence interval
+        FunctionName    string // Name of the lambda function
+        Qualifier       string // Qualifier of the lambda function
+        StartTime       time.Time // earliest considered invocation
+        EndTime         time.Time // latest considered invocation
+    }


### PR DESCRIPTION
This PR adds a duration function. It gathers various duration statistics, namely the following:

```
type DurationStatisticsReturn struct{
        MinDuration    float32 // Min duration of any run
        MaxDuration    float32 // Max duration of any run
        MedianDuration float32 // Median duration of any run
		MeanDuration   float32 // Mean duration of any run
        P95Duration    *float32 // Pointers as these values can be nil
        P99Duration    *float32 // in case of too little samples
		Conf95Duration *float32 // 95% confidence interval
        FunctionName    string // Name of the lambda function
        Qualifier       string // Qualifier of the lambda function
        StartTime       time.Time // earliest considered invocation
        EndTime         time.Time // latest considered invocation
    }
```

To gather them, logsinights is used instead of CloudWatch metrics. This is because with CloudWatch there is a risk of aggregating multiple durations into one, due to the period parameter, and thus distorting the results. 