### PR TITLE
Added a Cache to track the number of invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ There currently is no possibility to distinguish between different aliases in th
 
 ### What happens when a function has not been invoked in the specified interval?
 Since the goal was to let the user decide freely what to do in this case, a [custom error](./errors/errors.go) is thrown. You can use `errors.As` in your downstream logic to asses whether this error is raised and decide yourself how you want to treat this case.
+Whether a function has been invoked in a specific interval is cached internally, to reduce calls to cloudwatch metrics and thus alos charges to your AWS account.
 
 
 ## Available Metrics

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,73 @@
+// Copyright 2025 dominikhei
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Cache is a simple cache, which is used to store whether functions have been invoked yet.
+// This reduces the amount of API calls and cost in the metrics functions.
+// The cache gets deleted as soon as the process is killed.
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// CacheKey contains the identifiers of a lambda function and invocation interval.
+type CacheKey struct {
+	FunctionName string
+	Qualifier    string
+	Start        time.Time
+	End          time.Time
+}
+
+// This computes a string out of CacheKey
+func (k CacheKey) String() string {
+	return fmt.Sprintf("%s|%s|%d|%d", k.FunctionName, k.Qualifier, k.Start.Unix(), k.End.Unix())
+}
+
+// The actual cache implementation, thread safety is guaranteed via a mutex.
+// A CacheKey is only stored in it, if it has been invoked.
+type Cache struct {
+	mu    sync.RWMutex
+	store map[string]int // map from key string to invocation count
+}
+
+func NewCache() *Cache {
+	return &Cache{
+		store: make(map[string]int),
+	}
+}
+
+// Has returns true if the key exists in the cache.
+func (c *Cache) Has(key CacheKey) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.store[key.String()]
+	return ok
+}
+
+// Set stores the invocation count for the given key.
+func (c *Cache) Set(key CacheKey, count int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store[key.String()] = count
+}
+
+// Get returns the invocation count for the key and a bool indicating if it was found.
+func (c *Cache) Get(key CacheKey) (int, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	count, ok := c.store[key.String()]
+	return count, ok
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -24,6 +24,7 @@ import (
 )
 
 // CacheKey contains the identifiers of a lambda function and invocation interval.
+// It is not stored in the types package as CacheKey is not meant to be used by users.
 type CacheKey struct {
 	FunctionName string
 	Qualifier    string
@@ -37,7 +38,7 @@ func (k CacheKey) String() string {
 }
 
 // The actual cache implementation, thread safety is guaranteed via a mutex.
-// A CacheKey is only stored in it, if it has been invoked.
+// The cache stores the String() of a CacheKey and the amount of invocations.
 type Cache struct {
 	mu    sync.RWMutex
 	store map[string]int // map from key string to invocation count

--- a/internal/interfaces/interfaces.go
+++ b/internal/interfaces/interfaces.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
 
@@ -35,4 +36,10 @@ type CloudWatchFetcher interface {
 // This interface matches lambda.Client for tetsing the internal functions
 type LambdaClient interface {
 	GetFunction(ctx context.Context, params *lambda.GetFunctionInput, optFns ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error)
+}
+
+type Cache interface {
+	Has(key cache.CacheKey) bool
+	Set(key cache.CacheKey, value int)
+	Get(key cache.CacheKey) (int, bool)
 }

--- a/internal/metrics/coldstartduration.go
+++ b/internal/metrics/coldstartduration.go
@@ -43,6 +43,8 @@ func GetColdStartDurationStatistics(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.ColdStartDurationStatisticsReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/internal/metrics/coldstartduration.go
+++ b/internal/metrics/coldstartduration.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	sdkinterfaces "github.com/dominikhei/serverless-statistics/internal/interfaces"
 	"github.com/dominikhei/serverless-statistics/internal/queries"
 	"github.com/dominikhei/serverless-statistics/internal/utils"
@@ -38,16 +39,30 @@ func GetColdStartDurationStatistics(
 	ctx context.Context,
 	logsFetcher sdkinterfaces.LogsInsightsFetcher,
 	cwFetcher sdkinterfaces.CloudWatchFetcher,
+	invocationsCache sdkinterfaces.Cache,
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.ColdStartDurationStatisticsReturn, error) {
 
-	invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
-	if err != nil {
-		return nil, fmt.Errorf("fetch invocations metric: %w", err)
+	key := cache.CacheKey{
+		FunctionName: query.FunctionName,
+		Qualifier:    query.Qualifier,
+		Start:        query.StartTime,
+		End:          query.EndTime,
 	}
-	invocationsSum, err := utils.SumMetricValues(invocationsResults)
-	if err != nil {
-		return nil, fmt.Errorf("parse invocations metric data: %w", err)
+	var invocationsSum float64
+	if invocationsCache.Has(key) {
+		invocations, _ := invocationsCache.Get(key)
+		invocationsSum = float64(invocations)
+	} else {
+		invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
+		if err != nil {
+			return nil, fmt.Errorf("fetch invocations metric: %w", err)
+		}
+		invocationsSum, err = utils.SumMetricValues(invocationsResults)
+		if err != nil {
+			return nil, fmt.Errorf("parse invocations metric data: %w", err)
+		}
+		invocationsCache.Set(key, int(invocationsSum))
 	}
 	if invocationsSum == 0 {
 		return nil, &sdkerrors.NoInvocationsError{FunctionName: query.FunctionName}

--- a/internal/metrics/coldstartrate.go
+++ b/internal/metrics/coldstartrate.go
@@ -39,6 +39,8 @@ func GetColdStartRate(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.ColdStartRateReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/internal/metrics/duration.go
+++ b/internal/metrics/duration.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	sdkinterfaces "github.com/dominikhei/serverless-statistics/internal/interfaces"
 	"github.com/dominikhei/serverless-statistics/internal/queries"
 	"github.com/dominikhei/serverless-statistics/internal/utils"
@@ -38,16 +39,30 @@ func GetDurationStatistics(
 	ctx context.Context,
 	logsFetcher sdkinterfaces.LogsInsightsFetcher,
 	cwFetcher sdkinterfaces.CloudWatchFetcher,
+	invocationsCache sdkinterfaces.Cache,
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.DurationStatisticsReturn, error) {
 
-	invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
-	if err != nil {
-		return nil, fmt.Errorf("fetch invocations metric: %w", err)
+	key := cache.CacheKey{
+		FunctionName: query.FunctionName,
+		Qualifier:    query.Qualifier,
+		Start:        query.StartTime,
+		End:          query.EndTime,
 	}
-	invocationsSum, err := utils.SumMetricValues(invocationsResults)
-	if err != nil {
-		return nil, fmt.Errorf("parse invocations metric data: %w", err)
+	var invocationsSum float64
+	if invocationsCache.Has(key) {
+		invocations, _ := invocationsCache.Get(key)
+		invocationsSum = float64(invocations)
+	} else {
+		invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
+		if err != nil {
+			return nil, fmt.Errorf("fetch invocations metric: %w", err)
+		}
+		invocationsSum, err = utils.SumMetricValues(invocationsResults)
+		if err != nil {
+			return nil, fmt.Errorf("parse invocations metric data: %w", err)
+		}
+		invocationsCache.Set(key, int(invocationsSum))
 	}
 	if invocationsSum == 0 {
 		return nil, &sdkerrors.NoInvocationsError{FunctionName: query.FunctionName}

--- a/internal/metrics/duration.go
+++ b/internal/metrics/duration.go
@@ -43,6 +43,8 @@ func GetDurationStatistics(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.DurationStatisticsReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/internal/metrics/erroroccurences.go
+++ b/internal/metrics/erroroccurences.go
@@ -40,6 +40,8 @@ func GetErrorTypes(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.ErrorTypesReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/internal/metrics/erroroccurences.go
+++ b/internal/metrics/erroroccurences.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	sdkinterfaces "github.com/dominikhei/serverless-statistics/internal/interfaces"
 	"github.com/dominikhei/serverless-statistics/internal/queries"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
@@ -35,16 +36,30 @@ func GetErrorTypes(
 	ctx context.Context,
 	logsFetcher sdkinterfaces.LogsInsightsFetcher,
 	cwFetcher sdkinterfaces.CloudWatchFetcher,
+	invocationsCache sdkinterfaces.Cache,
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.ErrorTypesReturn, error) {
 
-	invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
-	if err != nil {
-		return nil, fmt.Errorf("fetch invocations metric: %w", err)
+	key := cache.CacheKey{
+		FunctionName: query.FunctionName,
+		Qualifier:    query.Qualifier,
+		Start:        query.StartTime,
+		End:          query.EndTime,
 	}
-	invocationsSum, err := utils.SumMetricValues(invocationsResults)
-	if err != nil {
-		return nil, fmt.Errorf("parse invocations metric data: %w", err)
+	var invocationsSum float64
+	if invocationsCache.Has(key) {
+		invocations, _ := invocationsCache.Get(key)
+		invocationsSum = float64(invocations)
+	} else {
+		invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
+		if err != nil {
+			return nil, fmt.Errorf("fetch invocations metric: %w", err)
+		}
+		invocationsSum, err = utils.SumMetricValues(invocationsResults)
+		if err != nil {
+			return nil, fmt.Errorf("parse invocations metric data: %w", err)
+		}
+		invocationsCache.Set(key, int(invocationsSum))
 	}
 	if invocationsSum == 0 {
 		return nil, &sdkerrors.NoInvocationsError{FunctionName: query.FunctionName}

--- a/internal/metrics/errorrate.go
+++ b/internal/metrics/errorrate.go
@@ -35,6 +35,8 @@ func GetErrorRate(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.ErrorRateReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/internal/metrics/memoryusage.go
+++ b/internal/metrics/memoryusage.go
@@ -38,6 +38,8 @@ func GetMaxMemoryUsageStatistics(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.MemoryUsagePercentilesReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/internal/metrics/memoryusage.go
+++ b/internal/metrics/memoryusage.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	sdkinterfaces "github.com/dominikhei/serverless-statistics/internal/interfaces"
 	"github.com/dominikhei/serverless-statistics/internal/queries"
 	"github.com/dominikhei/serverless-statistics/internal/utils"
@@ -33,16 +34,30 @@ func GetMaxMemoryUsageStatistics(
 	ctx context.Context,
 	logsFetcher sdkinterfaces.LogsInsightsFetcher,
 	cwFetcher sdkinterfaces.CloudWatchFetcher,
+	invocationsCache sdkinterfaces.Cache,
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.MemoryUsagePercentilesReturn, error) {
 
-	invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
-	if err != nil {
-		return nil, fmt.Errorf("fetch invocations metric: %w", err)
+	key := cache.CacheKey{
+		FunctionName: query.FunctionName,
+		Qualifier:    query.Qualifier,
+		Start:        query.StartTime,
+		End:          query.EndTime,
 	}
-	invocationsSum, err := utils.SumMetricValues(invocationsResults)
-	if err != nil {
-		return nil, fmt.Errorf("parse invocations metric data: %w", err)
+	var invocationsSum float64
+	if invocationsCache.Has(key) {
+		invocations, _ := invocationsCache.Get(key)
+		invocationsSum = float64(invocations)
+	} else {
+		invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
+		if err != nil {
+			return nil, fmt.Errorf("fetch invocations metric: %w", err)
+		}
+		invocationsSum, err = utils.SumMetricValues(invocationsResults)
+		if err != nil {
+			return nil, fmt.Errorf("parse invocations metric data: %w", err)
+		}
+		invocationsCache.Set(key, int(invocationsSum))
 	}
 	if invocationsSum == 0 {
 		return nil, &sdkerrors.NoInvocationsError{FunctionName: query.FunctionName}

--- a/internal/metrics/throttlerate.go
+++ b/internal/metrics/throttlerate.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	sdkinterfaces "github.com/dominikhei/serverless-statistics/internal/interfaces"
 	"github.com/dominikhei/serverless-statistics/internal/utils"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
@@ -30,16 +31,30 @@ import (
 func GetThrottleRate(
 	ctx context.Context,
 	cwFetcher sdkinterfaces.CloudWatchFetcher,
+	invocationsCache sdkinterfaces.Cache,
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.ThrottleRateReturn, error) {
 
-	invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
-	if err != nil {
-		return nil, fmt.Errorf("fetch invocations metric: %w", err)
+	key := cache.CacheKey{
+		FunctionName: query.FunctionName,
+		Qualifier:    query.Qualifier,
+		Start:        query.StartTime,
+		End:          query.EndTime,
 	}
-	invocationsSum, err := utils.SumMetricValues(invocationsResults)
-	if err != nil {
-		return nil, fmt.Errorf("parse invocations metric data: %w", err)
+	var invocationsSum float64
+	if invocationsCache.Has(key) {
+		invocations, _ := invocationsCache.Get(key)
+		invocationsSum = float64(invocations)
+	} else {
+		invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
+		if err != nil {
+			return nil, fmt.Errorf("fetch invocations metric: %w", err)
+		}
+		invocationsSum, err = utils.SumMetricValues(invocationsResults)
+		if err != nil {
+			return nil, fmt.Errorf("parse invocations metric data: %w", err)
+		}
+		invocationsCache.Set(key, int(invocationsSum))
 	}
 	if invocationsSum == 0 {
 		return nil, &sdkerrors.NoInvocationsError{FunctionName: query.FunctionName}

--- a/internal/metrics/throttlerate.go
+++ b/internal/metrics/throttlerate.go
@@ -35,6 +35,8 @@ func GetThrottleRate(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.ThrottleRateReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/internal/metrics/timeoutrate.go
+++ b/internal/metrics/timeoutrate.go
@@ -39,6 +39,8 @@ func GetTimeoutRate(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.TimeoutRateReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/internal/metrics/timeoutrate.go
+++ b/internal/metrics/timeoutrate.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	sdkinterfaces "github.com/dominikhei/serverless-statistics/internal/interfaces"
 	"github.com/dominikhei/serverless-statistics/internal/queries"
 	"github.com/dominikhei/serverless-statistics/internal/utils"
@@ -34,16 +35,30 @@ func GetTimeoutRate(
 	ctx context.Context,
 	cwFetcher sdkinterfaces.CloudWatchFetcher,
 	logsFetcher sdkinterfaces.LogsInsightsFetcher,
+	invocationsCache sdkinterfaces.Cache,
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.TimeoutRateReturn, error) {
 
-	invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
-	if err != nil {
-		return nil, fmt.Errorf("fetch invocations metric: %w", err)
+	key := cache.CacheKey{
+		FunctionName: query.FunctionName,
+		Qualifier:    query.Qualifier,
+		Start:        query.StartTime,
+		End:          query.EndTime,
 	}
-	invocationsSum, err := utils.SumMetricValues(invocationsResults)
-	if err != nil {
-		return nil, fmt.Errorf("parse invocations metric data: %w", err)
+	var invocationsSum float64
+	if invocationsCache.Has(key) {
+		invocations, _ := invocationsCache.Get(key)
+		invocationsSum = float64(invocations)
+	} else {
+		invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
+		if err != nil {
+			return nil, fmt.Errorf("fetch invocations metric: %w", err)
+		}
+		invocationsSum, err = utils.SumMetricValues(invocationsResults)
+		if err != nil {
+			return nil, fmt.Errorf("parse invocations metric data: %w", err)
+		}
+		invocationsCache.Set(key, int(invocationsSum))
 	}
 	if invocationsSum == 0 {
 		return nil, &sdkerrors.NoInvocationsError{FunctionName: query.FunctionName}

--- a/internal/metrics/wasteratio.go
+++ b/internal/metrics/wasteratio.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	sdkinterfaces "github.com/dominikhei/serverless-statistics/internal/interfaces"
 	"github.com/dominikhei/serverless-statistics/internal/queries"
 	"github.com/dominikhei/serverless-statistics/internal/utils"
@@ -34,16 +35,30 @@ func GetWasteRatio(
 	ctx context.Context,
 	cwFetcher sdkinterfaces.CloudWatchFetcher,
 	logsFetcher sdkinterfaces.LogsInsightsFetcher,
+	invocationsCache sdkinterfaces.Cache,
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.WasteRatioReturn, error) {
 
-	invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
-	if err != nil {
-		return nil, fmt.Errorf("fetch invocations metric: %w", err)
+	key := cache.CacheKey{
+		FunctionName: query.FunctionName,
+		Qualifier:    query.Qualifier,
+		Start:        query.StartTime,
+		End:          query.EndTime,
 	}
-	invocationsSum, err := utils.SumMetricValues(invocationsResults)
-	if err != nil {
-		return nil, fmt.Errorf("parse invocations metric data: %w", err)
+	var invocationsSum float64
+	if invocationsCache.Has(key) {
+		invocations, _ := invocationsCache.Get(key)
+		invocationsSum = float64(invocations)
+	} else {
+		invocationsResults, err := cwFetcher.FetchMetric(ctx, query, "Invocations", "Sum")
+		if err != nil {
+			return nil, fmt.Errorf("fetch invocations metric: %w", err)
+		}
+		invocationsSum, err = utils.SumMetricValues(invocationsResults)
+		if err != nil {
+			return nil, fmt.Errorf("parse invocations metric data: %w", err)
+		}
+		invocationsCache.Set(key, int(invocationsSum))
 	}
 	if invocationsSum == 0 {
 		return nil, &sdkerrors.NoInvocationsError{FunctionName: query.FunctionName}

--- a/internal/metrics/wasteratio.go
+++ b/internal/metrics/wasteratio.go
@@ -39,6 +39,8 @@ func GetWasteRatio(
 	query sdktypes.FunctionQuery,
 ) (*sdktypes.WasteRatioReturn, error) {
 
+	// cache reduces the number of calls to CloudWatch metrics.
+	// It lives as long as the Go process is running.
 	key := cache.CacheKey{
 		FunctionName: query.FunctionName,
 		Qualifier:    query.Qualifier,

--- a/tests/cache/cache_test.go
+++ b/tests/cache/cache_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 dominikhei
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dominikhei/serverless-statistics/internal/cache"
+)
+
+func TestCacheSetGetHas(t *testing.T) {
+	c := cache.NewCache()
+
+	key := cache.CacheKey{
+		FunctionName: "myFunc",
+		Qualifier:    "v1",
+		Start:        time.Unix(1000, 0),
+		End:          time.Unix(2000, 0),
+	}
+
+	if c.Has(key) {
+		t.Error("expected key to not exist")
+	}
+
+	count, ok := c.Get(key)
+	if ok {
+		t.Errorf("expected Get to return false for non-existing key, got count %d", count)
+	}
+
+	c.Set(key, 42)
+
+	if !c.Has(key) {
+		t.Error("expected key to exist")
+	}
+
+	count, ok = c.Get(key)
+	if !ok {
+		t.Error("expected Get to return true for existing key")
+	}
+	if count != 42 {
+		t.Errorf("expected count 42, got %d", count)
+	}
+}
+
+func TestCacheConcurrency(t *testing.T) {
+	c := cache.NewCache()
+	key := cache.CacheKey{
+		FunctionName: "func",
+		Qualifier:    "q",
+		Start:        time.Unix(0, 0),
+		End:          time.Unix(1, 0),
+	}
+
+	const n = 1000
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+
+	for i := 0; i < n; i++ {
+		go func(val int) {
+			defer wg.Done()
+			c.Set(key, val)
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			_, _ = c.Get(key)
+		}()
+	}
+
+	wg.Wait()
+}

--- a/tests/metrics/coldstartduration_test.go
+++ b/tests/metrics/coldstartduration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	"github.com/dominikhei/serverless-statistics/internal/metrics"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
@@ -44,6 +45,8 @@ func TestGetColdStartDurationStatistics_HappyPath(t *testing.T) {
 		},
 	}
 
+	cache := cache.NewCache()
+
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
 		Region:       "us-east-1",
@@ -52,7 +55,7 @@ func TestGetColdStartDurationStatistics_HappyPath(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetColdStartDurationStatistics(context.Background(), logs, cw, query)
+	result, err := metrics.GetColdStartDurationStatistics(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,7 +83,9 @@ func TestGetColdStartDurationStatistics_NoInvocations(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	_, err := metrics.GetColdStartDurationStatistics(context.Background(), logs, cw, query)
+	cache := cache.NewCache()
+
+	_, err := metrics.GetColdStartDurationStatistics(context.Background(), logs, cw, cache, query)
 	if err == nil {
 		t.Fatal("expected NoInvocationsError, got nil")
 	}
@@ -112,7 +117,9 @@ func TestGetColdStartDurationStatistics_InvalidDurationEntry(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetColdStartDurationStatistics(context.Background(), logs, cw, query)
+	cache := cache.NewCache()
+
+	result, err := metrics.GetColdStartDurationStatistics(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/tests/metrics/coldstartrate_test.go
+++ b/tests/metrics/coldstartrate_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	"github.com/dominikhei/serverless-statistics/internal/metrics"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
@@ -37,6 +38,7 @@ func TestGetColdStartRate_HappyPath(t *testing.T) {
 			{"totalInvocations": "100", "coldStartLines": "10"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -45,7 +47,7 @@ func TestGetColdStartRate_HappyPath(t *testing.T) {
 		StartTime:    time.Now().Add(-1 * time.Hour),
 		EndTime:      time.Now(),
 	}
-	result, err := metrics.GetColdStartRate(context.Background(), logs, cw, query)
+	result, err := metrics.GetColdStartRate(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -61,6 +63,7 @@ func TestGetColdStartRate_NoInvocations(t *testing.T) {
 		},
 	}
 	logs := &mockLogsFetcher{}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -69,7 +72,7 @@ func TestGetColdStartRate_NoInvocations(t *testing.T) {
 		StartTime:    time.Now().Add(-1 * time.Hour),
 		EndTime:      time.Now(),
 	}
-	_, err := metrics.GetColdStartRate(context.Background(), logs, cw, query)
+	_, err := metrics.GetColdStartRate(context.Background(), logs, cw, cache, query)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -91,6 +94,7 @@ func TestGetColdStartRate_EmptyLogData(t *testing.T) {
 			{"totalInvocations": "", "coldStartLines": ""},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -99,7 +103,7 @@ func TestGetColdStartRate_EmptyLogData(t *testing.T) {
 		StartTime:    time.Now().Add(-1 * time.Hour),
 		EndTime:      time.Now(),
 	}
-	result, err := metrics.GetColdStartRate(context.Background(), logs, cw, query)
+	result, err := metrics.GetColdStartRate(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/tests/metrics/duration_test.go
+++ b/tests/metrics/duration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	"github.com/dominikhei/serverless-statistics/internal/metrics"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
@@ -43,6 +44,7 @@ func TestGetDurationStatistics_HappyPath(t *testing.T) {
 			{"durationMs": "300"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -52,7 +54,7 @@ func TestGetDurationStatistics_HappyPath(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetDurationStatistics(context.Background(), logs, cw, query)
+	result, err := metrics.GetDurationStatistics(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,6 +73,7 @@ func TestGetDurationStatistics_NoInvocations(t *testing.T) {
 		},
 	}
 	logs := &mockLogsFetcher{}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "empty-fn",
@@ -80,7 +83,7 @@ func TestGetDurationStatistics_NoInvocations(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	_, err := metrics.GetDurationStatistics(context.Background(), logs, cw, query)
+	_, err := metrics.GetDurationStatistics(context.Background(), logs, cw, cache, query)
 	if err == nil {
 		t.Fatal("expected NoInvocationsError, got nil")
 	}
@@ -103,6 +106,7 @@ func TestGetDurationStatistics_InvalidDurationEntry(t *testing.T) {
 			{"durationMs": "300"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "broken-fn",
@@ -112,7 +116,7 @@ func TestGetDurationStatistics_InvalidDurationEntry(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetDurationStatistics(context.Background(), logs, cw, query)
+	result, err := metrics.GetDurationStatistics(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/tests/metrics/erroroccurences_test.go
+++ b/tests/metrics/erroroccurences_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	"github.com/dominikhei/serverless-statistics/internal/metrics"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
@@ -37,6 +38,7 @@ func TestGetErrorTypes_HappyPath(t *testing.T) {
 			{"error_category": "ValidationError", "error_count": "3"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "my-function",
@@ -45,7 +47,7 @@ func TestGetErrorTypes_HappyPath(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetErrorTypes(context.Background(), logs, cw, query)
+	result, err := metrics.GetErrorTypes(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,6 +68,7 @@ func TestGetErrorTypes_NoInvocations(t *testing.T) {
 		results: []types.MetricDataResult{{Values: []float64{0}}},
 	}
 	logs := &mockLogsFetcher{}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "empty-fn",
@@ -74,7 +77,7 @@ func TestGetErrorTypes_NoInvocations(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	_, err := metrics.GetErrorTypes(context.Background(), logs, cw, query)
+	_, err := metrics.GetErrorTypes(context.Background(), logs, cw, cache, query)
 	if err == nil {
 		t.Fatal("expected NoInvocationsError, got nil")
 	}
@@ -94,6 +97,7 @@ func TestGetErrorTypes_InvalidErrorCount(t *testing.T) {
 			{"error_category": "ValidationError", "error_count": "7"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "broken-fn",
@@ -102,7 +106,7 @@ func TestGetErrorTypes_InvalidErrorCount(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetErrorTypes(context.Background(), logs, cw, query)
+	result, err := metrics.GetErrorTypes(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -125,6 +129,7 @@ func TestGetErrorTypes_MissingErrorCategory(t *testing.T) {
 			{"error_count": "6"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "missing-cat-fn",
@@ -133,7 +138,7 @@ func TestGetErrorTypes_MissingErrorCategory(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetErrorTypes(context.Background(), logs, cw, query)
+	result, err := metrics.GetErrorTypes(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/tests/metrics/errorrate_test.go
+++ b/tests/metrics/errorrate_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	"github.com/dominikhei/serverless-statistics/internal/metrics"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
@@ -33,6 +34,8 @@ func TestGetErrorRate_HappyPath(t *testing.T) {
 		},
 		err: nil,
 	}
+	cache := cache.NewCache()
+
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
 		Region:       "us-east-1",
@@ -41,7 +44,7 @@ func TestGetErrorRate_HappyPath(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetErrorRate(context.Background(), mockCW, query)
+	result, err := metrics.GetErrorRate(context.Background(), mockCW, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,6 +60,8 @@ func TestGetErrorRate_NoInvocations(t *testing.T) {
 		},
 		err: nil,
 	}
+	cache := cache.NewCache()
+
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
 		Region:       "us-east-1",
@@ -65,7 +70,7 @@ func TestGetErrorRate_NoInvocations(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	_, err := metrics.GetErrorRate(context.Background(), mockCW, query)
+	_, err := metrics.GetErrorRate(context.Background(), mockCW, cache, query)
 	if err == nil {
 		t.Fatal("expected NoInvocationsError, got nil")
 	}

--- a/tests/metrics/memoryusage_test.go
+++ b/tests/metrics/memoryusage_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	"github.com/dominikhei/serverless-statistics/internal/metrics"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
@@ -42,6 +43,7 @@ func TestGetMaxMemoryUsageStatistics_HappyPath(t *testing.T) {
 			{"memoryUtilizationRatio": "0.9"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -51,7 +53,7 @@ func TestGetMaxMemoryUsageStatistics_HappyPath(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetMaxMemoryUsageStatistics(context.Background(), logs, cw, query)
+	result, err := metrics.GetMaxMemoryUsageStatistics(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,6 +73,7 @@ func TestGetMaxMemoryUsageStatistics_NoInvocations(t *testing.T) {
 		},
 	}
 	logs := &mockLogsFetcher{}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "empty-fn",
@@ -80,7 +83,7 @@ func TestGetMaxMemoryUsageStatistics_NoInvocations(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	_, err := metrics.GetMaxMemoryUsageStatistics(context.Background(), logs, cw, query)
+	_, err := metrics.GetMaxMemoryUsageStatistics(context.Background(), logs, cw, cache, query)
 	if err == nil {
 		t.Fatal("expected NoInvocationsError, got nil")
 	}
@@ -103,6 +106,7 @@ func TestGetMaxMemoryUsageStatistics_InvalidMemoryUtilizationEntry(t *testing.T)
 			{"memoryUtilizationRatio": "0.7"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "broken-fn",
@@ -112,7 +116,7 @@ func TestGetMaxMemoryUsageStatistics_InvalidMemoryUtilizationEntry(t *testing.T)
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetMaxMemoryUsageStatistics(context.Background(), logs, cw, query)
+	result, err := metrics.GetMaxMemoryUsageStatistics(context.Background(), logs, cw, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/tests/metrics/timeoutrate_test.go
+++ b/tests/metrics/timeoutrate_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	"github.com/dominikhei/serverless-statistics/internal/metrics"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
@@ -40,6 +41,7 @@ func TestGetTimeoutRate_HappyPath(t *testing.T) {
 		},
 		err: nil,
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -49,7 +51,7 @@ func TestGetTimeoutRate_HappyPath(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetTimeoutRate(context.Background(), cw, logs, query)
+	result, err := metrics.GetTimeoutRate(context.Background(), cw, logs, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -73,8 +75,9 @@ func TestGetTimeoutRate_NoInvocations(t *testing.T) {
 		FunctionName: "test-fn",
 	}
 	logs := &mockLogsFetcher{}
+	cache := cache.NewCache()
 
-	_, err := metrics.GetTimeoutRate(context.Background(), cw, logs, query)
+	_, err := metrics.GetTimeoutRate(context.Background(), cw, logs, cache, query)
 	if err == nil {
 		t.Fatal("expected error for no invocations, got nil")
 	}
@@ -94,6 +97,7 @@ func TestGetTimeoutRate_ParseInvocationCountError(t *testing.T) {
 		},
 		err: nil,
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -103,7 +107,7 @@ func TestGetTimeoutRate_ParseInvocationCountError(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	_, err := metrics.GetTimeoutRate(context.Background(), cw, logs, query)
+	_, err := metrics.GetTimeoutRate(context.Background(), cw, logs, cache, query)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -122,6 +126,7 @@ func TestGetTimeoutRate_ZeroTimeoutCount(t *testing.T) {
 		},
 		err: nil,
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -131,7 +136,7 @@ func TestGetTimeoutRate_ZeroTimeoutCount(t *testing.T) {
 		EndTime:      time.Now(),
 	}
 
-	result, err := metrics.GetTimeoutRate(context.Background(), cw, logs, query)
+	result, err := metrics.GetTimeoutRate(context.Background(), cw, logs, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/tests/metrics/wasteratio_test.go
+++ b/tests/metrics/wasteratio_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	sdkerrors "github.com/dominikhei/serverless-statistics/errors"
+	"github.com/dominikhei/serverless-statistics/internal/cache"
 	"github.com/dominikhei/serverless-statistics/internal/metrics"
 	sdktypes "github.com/dominikhei/serverless-statistics/types"
 )
@@ -37,6 +38,7 @@ func TestGetWasteRatio_HappyPath(t *testing.T) {
 			{"totalDuration": "100", "totalBilledDuration": "110"},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -45,7 +47,7 @@ func TestGetWasteRatio_HappyPath(t *testing.T) {
 		StartTime:    time.Now().Add(-1 * time.Hour),
 		EndTime:      time.Now(),
 	}
-	result, err := metrics.GetWasteRatio(context.Background(), cw, logs, query)
+	result, err := metrics.GetWasteRatio(context.Background(), cw, logs, cache, query)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -61,6 +63,7 @@ func TestGetWasteRatio_NoInvocations(t *testing.T) {
 		},
 	}
 	logs := &mockLogsFetcher{}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -69,7 +72,7 @@ func TestGetWasteRatio_NoInvocations(t *testing.T) {
 		StartTime:    time.Now().Add(-1 * time.Hour),
 		EndTime:      time.Now(),
 	}
-	_, err := metrics.GetWasteRatio(context.Background(), cw, logs, query)
+	_, err := metrics.GetWasteRatio(context.Background(), cw, logs, cache, query)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -91,6 +94,7 @@ func TestGetWasteRatio_EmptyLogData(t *testing.T) {
 			{"totalDuration": "", "totalBilledDuration": ""},
 		},
 	}
+	cache := cache.NewCache()
 
 	query := sdktypes.FunctionQuery{
 		FunctionName: "test-fn",
@@ -99,7 +103,7 @@ func TestGetWasteRatio_EmptyLogData(t *testing.T) {
 		StartTime:    time.Now().Add(-1 * time.Hour),
 		EndTime:      time.Now(),
 	}
-	_, err := metrics.GetWasteRatio(context.Background(), cw, logs, query)
+	_, err := metrics.GetWasteRatio(context.Background(), cw, logs, cache, query)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
This PR introduces an in-memory cache to reduce the number of calls made to CloudWatch metrics. The cache persists for the lifetime of the Go process, improving performance by avoiding redundant metric queries and reducing cost.

### Details
Cache stores the number of invocations of a function in an interval as this metric is used by every metric function.
Cache entries expire when the Go process stops (i.e., no persistent storage).
This reduces API calls, speeds up metric retrieval, and lowers cost.
### Impact
Cache validity is limited to the running process lifetime.
On process restart, the cache clears, and metrics are fetched fresh.
No changes to external behavior, only performance improvements

The cache is especially helpful, if multiple metrics are computed for one interval and function, as it now requires one call to CloudWatch metrics for the number of invocations instead of n ones.